### PR TITLE
Commit from inside of container from Diamond workstation

### DIFF
--- a/src/service/app.py
+++ b/src/service/app.py
@@ -6,7 +6,7 @@ def make_app() -> FastAPI:
 
     @app.get("/test", status_code=status.HTTP_200_OK)
     def broken_endpoint():
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return {}
 
     @app.get("/healthz", status_code=status.HTTP_200_OK)
     def health_endpoint():


### PR DESCRIPTION
https://github.com/DiamondJoseph/debug-service/pull/13
I have it working from Zoheb's work station

Here's what I did:
- `module load pollux`
- Deploy broken container: `helm install test oci://ghcr.io/diamondjoseph/charts/service --version 0.1.5 --set service.type=LoadBalancer --set service.port=8000 --set image.tag=0.1.5`  # appVersion in the helm chart is wrong
- helm will print how to find the service address
- Check that <service address>/healthz is happy (check the browser console to ensure it's a 200 return code) and <service address>/test is unhappy (return code >=400)

---
In theory this is where you are at when you notice a problem with the service.

- check out source of this repository at the version of your deployed container
- module load vscode
- code .
- install the kubernetes extension (if required)
- ctrl-shift-p -> "Open User Settings (JSON)" -> add `"vs-kubernetes": {"vs-kubernetes.helm-path.linux" : "", "vs-kubernetes.kubectl-path.linux": ""}` if they are not present- you may need to remove the values if they are?

- Deploy debug container: `helm upgrade --install test oci://ghcr.io/diamondjoseph/charts/service --version 0.1.5 -f values.yaml`  # see values.yaml at bottom: in deployment it would be `helm upgrade --install <name> <chart> --reuse-values -f values.yaml`
- ~~copy pollux kubeconfig as ~/.kube/config~~ (Not required on Keith's machine?)
- attach vscode 
- start service with `python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:5678 -m service serve --host 0.0.0.0 --port 8000`
- Check that <service address>/healthz is happy and <service address>/test is unhappy

---
You've now checked that the devcontainer inside the cluster is able to run with all required infrastructure

- May need to install the Debugpy extension in the devcontainer, make a launch configuration for "remote" attaching to running service, configuring autoreload
- Attach debugger from inside devcontainer, inspect variables, use breakpoints, hot swap code; or stop service running from the terminal, make changes, re-deploy
- Get to a point where <service address>/test works
- make a commit and push

values.yaml: replace fedid/uid with yours!
```yaml
volumes:
- name: home  # Required for vscode to install plugins
  hostPath:
    path: /home/qwe67581
- name: nslcd  # Shared volume between main and sidecar container
  emptyDir:
    sizeLimit: 500Mi

volumeMounts:
- mountPath: /home/qwe67581/
  name: home
- mountPath: /var/run/nslcd
  name: nslcd

# Disable any liveness probe, as will not start service automatically
livenessProbe: null
readinessProbe: null

# Required to mount /home/, /dls/ etc.
podSecurityContext:
  runAsUser: 1215763
  runAsGroup: 1215763

debug:
  enabled: true
  home: /home/qwe67581/

image:
  tag: 0.1.5

service:
  type: LoadBalancer
  port: 8000
```